### PR TITLE
feat: add auth context support for login and signup flow

### DIFF
--- a/Client/.gitignore
+++ b/Client/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+README.md
 
 # Editor directories and files
 .vscode/*
@@ -22,3 +23,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+

--- a/Client/README.md
+++ b/Client/README.md
@@ -21,9 +21,28 @@ Ye README Hinglish me maintain kiya gaya hai, taaki abhi tak kya bana hai aur se
 4. Google login component integrated hai (`@react-oauth/google`).
 5. Dashboard UI ready hai (name/email/avatar localStorage se read hota hai).
 6. Chat component me old full layout code present hai, lekin abhi comment mode me.
-7. Current active routes mainly:
+7. Login form backend `POST /auth/login` ke saath connected hai.
+8. `AuthProvider` + `useAuth` context add kiya gaya hai auth state share karne ke liye.
+9. App root ko `AuthProvider` se wrap kiya gaya hai, taaki global auth state available rahe.
+10. Login aur Signup dono API response ko `localStorage("messenger")` ke saath auth context me bhi sync karte hain.
+11. Initial auth state cookie `jwt` ya localStorage se read hoti hai (`js-cookies` use karke).
+12. Current active routes mainly:
    - `/chat`
    - `/*` (PageNotFound fallback)
+13. Current testing flow me `Chat.jsx` temporary taur par `Signup` aur `Login` components render kar raha hai.
+
+## 2.1) Client Auth Flow (Naya)
+
+1. `Client/src/context/AuthProvider.jsx`
+   - `AuthContext` create karta hai
+   - `authUser` aur `setAuthUser` expose karta hai
+   - startup par `jwt` cookie ya `messenger` localStorage se user state hydrate karta hai
+2. `Client/src/main.jsx`
+   - pure app ko `AuthProvider` se wrap karta hai
+3. `Client/src/components/Login.jsx`
+   - successful login ke baad response ko localStorage aur auth context dono me save karta hai
+4. `Client/src/components/Signup.jsx`
+   - successful signup ke baad response ko localStorage aur auth context dono me save karta hai
 
 ## 3) Server Route Mapping
 
@@ -124,8 +143,8 @@ Base route: `/auth`
 
 ## 7) Pending Work (Recommended Next)
 
-1. `Login.jsx` ko backend `POST /auth/login` se connect karna.
-2. `App.jsx` me login/dashboard/private route flow activate karna.
+1. `App.jsx` me login/dashboard/private route flow activate karna.
+2. `Chat.jsx` me temporary `Signup`/`Login` rendering hata kar actual auth-based screen switch restore karna.
 3. `secure: "strict"` ko cookie config me proper boolean strategy ke saath revise karna (dev/prod basis).
 4. Error handling standardize karna:
    - backend key mostly `message` hai, to frontend me `error.response.data.message` use karo.

--- a/Client/package-lock.json
+++ b/Client/package-lock.json
@@ -17,6 +17,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.34.4",
+        "js-cookies": "^1.0.4",
         "lucide-react": "^0.576.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -3068,6 +3069,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-cookies": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/js-cookies/-/js-cookies-1.0.4.tgz",
+      "integrity": "sha512-cO1SHDH7zJsi8FihHmDtcWx90mWmrfGOrcLKPeaEX6tLyuTK2wnzgdmNa34Q6rNAd6VhQUgjDt5Eyl90VI/Fpg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/Client/package.json
+++ b/Client/package.json
@@ -19,6 +19,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.34.4",
+    "js-cookies": "^1.0.4",
     "lucide-react": "^0.576.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/Client/src/components/Chat.jsx
+++ b/Client/src/components/Chat.jsx
@@ -4,11 +4,15 @@ import Right from "@/Home/right/Right";
 import React from "react";
 import Signup from "./Signup";
 import Login from "./Login";
+// import { useAuth } from "../context/AuthProvider";
 
 const Chat = () => {
+  // const { authUser } = useAuth();
+  // console.log(authUser);
+
   return (
     <>
-      <div className="h-screen w-screen overflow-hidden bg-[#d9e0ff]">
+      {/* <div className="h-screen w-screen overflow-hidden bg-[#d9e0ff]">
         <div className="flex h-full w-full overflow-hidden bg-white">
           <aside className="flex h-full w-[30%] min-w-[280px] border-r border-[#e7ecff] bg-[#f7f9ff]">
             <div className="flex h-full w-[12%] min-w-10 flex-col items-center justify-end border-r border-[#e7ecff] px-1 py-4">
@@ -22,9 +26,9 @@ const Chat = () => {
             <Right />
           </main>
         </div>
-      </div>
-      {/* <Signup />
-      <Login /> */}
+      </div> */}
+      <Signup />
+      <Login />
     </>
   );
 };

--- a/Client/src/components/Login.jsx
+++ b/Client/src/components/Login.jsx
@@ -2,8 +2,12 @@ import { useForm } from "react-hook-form";
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import api from "../../api";
+import { useAuth } from "@/context/AuthProvider";
+
 
 const Login = () => {
+    const { setAuthUser } = useAuth();
+  
   // const passwordValue = watch("password", "");
   const [showPassword, setShowPassword] = useState(false);
 
@@ -30,6 +34,7 @@ const Login = () => {
       }
 
       localStorage.setItem("messenger", JSON.stringify(response.data));
+      setAuthUser(response.data);
     } catch (error) {
       console.log("Full error:", error);
       console.log("Error response:", error?.response);

--- a/Client/src/components/Signup.jsx
+++ b/Client/src/components/Signup.jsx
@@ -2,8 +2,11 @@ import { useForm } from "react-hook-form";
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import api from "../../api";
+import { useAuth } from "../context/AuthProvider";
+
 
 const Signup = () => {
+  const { setAuthUser } = useAuth();
   const {
     register,
     handleSubmit,
@@ -28,6 +31,7 @@ const Signup = () => {
       }
 
       localStorage.setItem("messenger", JSON.stringify(response.data));
+      setAuthUser(response.data);
     } catch (error) {
       console.log("Full error:", error);
       console.log("Error response:", error?.response);
@@ -329,3 +333,5 @@ const Signup = () => {
 };
 
 export default Signup;
+
+

--- a/Client/src/context/AuthProvider.jsx
+++ b/Client/src/context/AuthProvider.jsx
@@ -1,0 +1,28 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState } from "react";
+import Cookies from "js-cookies";
+export const AuthContext = createContext();
+
+function AuthProvider ({ children }) {
+  //yahape hamne cookie me token store kiya hai or wo token hamne localstorage me se liye he
+  const initialUserState =
+    Cookies.getItem("jwt") || localStorage.getItem("messenger");
+
+  //parse the user data and stories in state
+  const [authUser, setAuthUser] = useState(
+    //parse q karte he
+    //ans q ki jab local storage me data save hoti he toh wo string ki form me hoti he parse karne pe wo object ke form me banjati he
+    initialUserState ? JSON.parse(initialUserState) : undefined,
+  );
+
+  return (
+    <>
+      <AuthContext.Provider value={{ authUser, setAuthUser }}>
+        {children}
+      </AuthContext.Provider>
+    </>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);
+export default AuthProvider;

--- a/Client/src/main.jsx
+++ b/Client/src/main.jsx
@@ -2,5 +2,10 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
+import AuthProvider from "./context/AuthProvider";
 
-createRoot(document.getElementById("root")).render(<App />);
+createRoot(document.getElementById("root")).render(
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+);


### PR DESCRIPTION
- create `AuthProvider` and `useAuth` to manage shared auth state
- wrap app with auth provider in `main.jsx`
- update `Login.jsx` to store API response in auth context after login
- update `Signup.jsx` to sync signup response with auth state/local storage
- add `js-cookies` dependency and adjust `Chat.jsx` for auth flow testing